### PR TITLE
fix: added 'id' to projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
 
 
 
-<section class="work" >
+<section class="work" id="projects" >
   <div class="heading">
     <div class="card">
       <div class="card-block">


### PR DESCRIPTION
The projects link in the navbar is not working as the projects section does not have an id = "projects", hence not forming a link with the project's anchor element in the navbar.